### PR TITLE
Add config option to use accessible colors

### DIFF
--- a/lib/caniuse-view.js
+++ b/lib/caniuse-view.js
@@ -170,7 +170,6 @@ class AtomCaniuseView extends SelectListView {
       .then((data) => {
         this.data = data
         this.removeClass('no-data')
-        console.log(atom.config.get(`caniuse.useAccessibleColors`))
         this.toggleClass('accessible-colors', atom.config.get(`caniuse.useAccessibleColors`))
         this.setItems(Object.keys(this.data.data)
           .map((key) => $.extend({ key }, this.data.data[key]))

--- a/lib/caniuse-view.js
+++ b/lib/caniuse-view.js
@@ -170,6 +170,8 @@ class AtomCaniuseView extends SelectListView {
       .then((data) => {
         this.data = data
         this.removeClass('no-data')
+        console.log(atom.config.get(`caniuse.useAccessibleColors`))
+        this.toggleClass('accessible-colors', atom.config.get(`caniuse.useAccessibleColors`))
         this.setItems(Object.keys(this.data.data)
           .map((key) => $.extend({ key }, this.data.data[key]))
           .sort((a, b) => a.title.localeCompare(b.title)))

--- a/lib/config.json
+++ b/lib/config.json
@@ -69,5 +69,10 @@
     "title": "Show UC Browser for Android",
     "type": "boolean",
     "default": false
+  },
+  "useAccessibleColors": {
+    "title": "Use accessible colors",
+    "type": "boolean",
+    "default": false
   }
 }

--- a/lib/config.json
+++ b/lib/config.json
@@ -71,7 +71,6 @@
     "default": false
   },
   "useAccessibleColors": {
-    "title": "Use accessible colors",
     "type": "boolean",
     "default": false
   }

--- a/styles/caniuse.less
+++ b/styles/caniuse.less
@@ -126,4 +126,20 @@
       }
     }
 
+    &.accessible-colors {
+        table td {
+            &.is-supported {
+                color: black;
+                background-color: #a6edb2;
+            }
+            &.is-almost-supported {
+                color: black;
+                background-color: #97bff0;
+            }
+            &.is-unsupported {
+                color: white;
+                background-color: #842e98;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Hi,

Your package is really great, thanks for making it. But, as a colorblind, one feature that I really like on the caniuse website is the possibility to switch the table colors to a more accessibles variants, which I can see with my eyes.

So I've added this feature in your package _via_ a new setting, allowing your users to choose between the original colors (by default), and the accessible variant from the caniuse website, as in the screenshot below.

<img width="540" alt="screen shot on 2015-12-29 at 02-15-02" src="https://cloud.githubusercontent.com/assets/692824/12028111/16377774-add2-11e5-9536-463aa3dc8e18.png">

Hope you'll like (and merge) it, its a really useful feature for people like me :)

Regards,
